### PR TITLE
fix(webdriverio): set env variable before running wdio

### DIFF
--- a/webdriver/webdriverio/package.json
+++ b/webdriver/webdriverio/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "test": "wdio run wdio.conf.js",
+    "test": "TAURI_AUTOMATION=true wdio run wdio.conf.js",
     "format": "prettier --write \"./**/*.js\""
   },
   "devDependencies": {


### PR DESCRIPTION
I see that tauri-driver is setting this env variable, which in theory should pass down to the child processes WebKitWebDriver and then hello_tauri.

But in practice it does not seem to. Because of that, the request to start the webdriver session hangs and eventually times out.

Setting the env variable before running wdio resolves the issue, and webdriverio tests runs properly.